### PR TITLE
Users can now edit books post-creation

### DIFF
--- a/to_dont_list/lib/objects/book.dart
+++ b/to_dont_list/lib/objects/book.dart
@@ -1,12 +1,14 @@
 class Book {
-   Book({required this.name, required this.isFiction,  this.progress = 0 });
-  final String name;
+  Book({required this.name, required this.isFiction, this.progress = 0});
+  //changed name and isFiction to no longer be final, so they can be edited
+  String name;
   double progress;
-  final bool isFiction;
-  void changeProgress( double newProgress){
+  bool isFiction;
+  void changeProgress(double newProgress) {
     progress = newProgress;
   }
-  void increaseProgress(){
+
+  void increaseProgress() {
     progress = progress + .02;
   }
 }

--- a/to_dont_list/lib/widgets/edit_book_dialog.dart
+++ b/to_dont_list/lib/widgets/edit_book_dialog.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+typedef BookEditedCallback = Function(String value,
+    TextEditingController textConroller, double sliderValue, bool switchValue);
+
+class EditBookDialog extends StatefulWidget {
+  const EditBookDialog({
+    super.key,
+    required this.onEditConfirmed,
+  });
+
+  final BookEditedCallback onEditConfirmed;
+
+  @override
+  State<EditBookDialog> createState() => _EditBookDialogState();
+}
+
+class _EditBookDialogState extends State<EditBookDialog> {
+  final TextEditingController _inputController = TextEditingController();
+  final ButtonStyle fictionStyle = ElevatedButton.styleFrom(
+      textStyle: const TextStyle(fontSize: 20), backgroundColor: Colors.red);
+  final ButtonStyle nonFictionStyle = ElevatedButton.styleFrom(
+      textStyle: const TextStyle(fontSize: 20), backgroundColor: Colors.green);
+
+  String valueText = "";
+  double sliderValue = .0;
+  bool switchValue = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Edit Book'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            onChanged: (value) {
+              setState(() {
+                valueText = value;
+              });
+            },
+            controller: _inputController,
+            decoration: const InputDecoration(hintText: "enter new name"),
+          ),
+          Slider(
+            min: 0,
+            max: 1,
+            value: sliderValue,
+            onChanged: (double value) {
+              setState(() {
+                sliderValue = value;
+              });
+            },
+          ),
+          SwitchListTile(
+              value: switchValue,
+              onChanged: (bool value) {
+                setState(() {
+                  switchValue = value;
+                });
+              },
+              title: RichText(
+                text: const TextSpan(
+                  children: <TextSpan>[
+                    TextSpan(
+                        text: 'Is your book ',
+                        style: TextStyle(color: Color.fromARGB(255, 0, 0, 0))),
+                    TextSpan(
+                        text: 'Fiction', style: TextStyle(color: Colors.red)),
+                    TextSpan(
+                        text: ' or ',
+                        style: TextStyle(color: Color.fromARGB(255, 0, 0, 0))),
+                    TextSpan(
+                        text: 'Non-Fiction',
+                        style: TextStyle(color: Colors.green)),
+                    TextSpan(
+                        text: ' ?',
+                        style: TextStyle(color: Color.fromARGB(255, 0, 0, 0)))
+                  ],
+                ),
+              )),
+        ],
+      ),
+      actions: <Widget>[
+        ValueListenableBuilder<TextEditingValue>(
+          valueListenable: _inputController,
+          builder: (context, value, child) {
+            return ElevatedButton(
+              key: const Key("OKButton"),
+              style: nonFictionStyle,
+              onPressed: value.text.isNotEmpty
+                  ? () {
+                      setState(() {
+                        widget.onEditConfirmed(valueText, _inputController,
+                            sliderValue, !switchValue);
+                        Navigator.pop(context);
+                      });
+                    }
+                  : null,
+              child: const Text('OK'),
+            );
+          },
+        ),
+        ElevatedButton(
+          key: const Key("CancelButton"),
+          style: fictionStyle,
+          child: const Text('Cancel'),
+          onPressed: () {
+            setState(() {
+              Navigator.pop(context);
+            });
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/to_dont_list/lib/widgets/edit_book_dialog.dart
+++ b/to_dont_list/lib/widgets/edit_book_dialog.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 typedef BookEditedCallback = Function(String value,
     TextEditingController textConroller, double sliderValue, bool switchValue);
 
+// This is the new dialog box that pops up for editing
+// It's triggered by the new edit button beside each book entry
 class EditBookDialog extends StatefulWidget {
   const EditBookDialog({
     super.key,
@@ -40,7 +42,7 @@ class _EditBookDialogState extends State<EditBookDialog> {
               });
             },
             controller: _inputController,
-            decoration: const InputDecoration(hintText: "enter new name"),
+            decoration: const InputDecoration(hintText: "Enter new name:"),
           ),
           Slider(
             min: 0,
@@ -59,6 +61,9 @@ class _EditBookDialogState extends State<EditBookDialog> {
                   switchValue = value;
                 });
               },
+              // Changes the switch colors to match fiction/nonfiction choices
+              activeColor: Colors.green,
+              inactiveThumbColor: Colors.red,
               title: RichText(
                 text: const TextSpan(
                   children: <TextSpan>[

--- a/to_dont_list/lib/widgets/to_do_items.dart
+++ b/to_dont_list/lib/widgets/to_do_items.dart
@@ -4,10 +4,9 @@ import 'package:to_dont_list/objects/book.dart';
 typedef ToDoListChangedCallback = Function(Book item, bool completed);
 typedef ToDoListRemovedCallback = Function(Book item);
 
-
 class BookItem extends StatefulWidget {
   BookItem(
-  {required this.item,
+      {required this.item,
       required this.completed,
       required this.onListChanged,
       required this.onDeleteItem})
@@ -51,20 +50,31 @@ class _BookItemState extends State<BookItem> {
         setState(() {
           widget.item.increaseProgress();
         });
-        
       },
       onLongPress: widget.completed
           ? () {
               setState(() {
-          widget.onDeleteItem(widget.item);
-        });
+                widget.onDeleteItem(widget.item);
+              });
             }
           : null,
-      leading: CircularProgressIndicator(
-        value: widget.item.progress,
-        backgroundColor: Colors.black54,
-        color: widget.item.isFiction == true ? Colors.red : Colors.green
-        //child: Text(item.abbrev()),
+      // Added Icon next to progress button
+      // Now when the icon is pressed it will open the edit book dialog
+      leading: Row(
+        children: [
+          CircularProgressIndicator(
+              value: widget.item.progress,
+              backgroundColor: Colors.black54,
+              color: widget.item.isFiction == true ? Colors.red : Colors.green
+              //child: Text(item.abbrev()),
+              ),
+          IconButton(
+            icon: const Icon(Icons.edit),
+            onPressed: () {
+              // Open edit book dialog here when tapped
+            },
+          ),
+        ],
       ),
       title: Text(
         widget.item.name,
@@ -72,4 +82,4 @@ class _BookItemState extends State<BookItem> {
       ),
     );
   }
-  }
+}

--- a/to_dont_list/lib/widgets/to_do_items.dart
+++ b/to_dont_list/lib/widgets/to_do_items.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:to_dont_list/objects/book.dart';
+import 'package:to_dont_list/widgets/edit_book_dialog.dart';
 
 typedef ToDoListChangedCallback = Function(Book item, bool completed);
 typedef ToDoListRemovedCallback = Function(Book item);
@@ -34,6 +35,17 @@ class _BookItemState extends State<BookItem> {
         : Theme.of(context).primaryColor;
   }
 
+  // Changes the values of the book to the new ones input by user
+  // Similar to the method in main that triggers todo dialog
+  void _handleChangedValues(String newName, TextEditingController controller,
+      double newProgress, bool isFiction) {
+    setState(() {
+      widget.item.name = newName;
+      widget.item.progress = newProgress;
+      widget.item.isFiction = isFiction;
+    });
+  }
+
   TextStyle? _getTextStyle(BuildContext context) {
     if (!widget.completed) return null;
 
@@ -58,9 +70,9 @@ class _BookItemState extends State<BookItem> {
               });
             }
           : null,
-      // Added Icon next to progress button
-      // Now when the icon is pressed it will open the edit book dialog
+      // Added Icon next to progress indicator
       leading: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
           CircularProgressIndicator(
               value: widget.item.progress,
@@ -68,12 +80,18 @@ class _BookItemState extends State<BookItem> {
               color: widget.item.isFiction == true ? Colors.red : Colors.green
               //child: Text(item.abbrev()),
               ),
+          // When the icon is pressed it will open the edit book dialog
           IconButton(
-            icon: const Icon(Icons.edit),
-            onPressed: () {
-              // Open edit book dialog here when tapped
-            },
-          ),
+              icon: const Icon(Icons.edit),
+              onPressed: () {
+                showDialog(
+                    context: context,
+                    builder: (_) {
+                      return EditBookDialog(
+                          onEditConfirmed: _handleChangedValues);
+                    });
+              },
+              color: widget.item.isFiction == true ? Colors.red : Colors.green),
         ],
       ),
       title: Text(


### PR DESCRIPTION
There is now a new edit button included with each of the book items in the list. Once pressed it will open a dialog box similar to the dialog where you create a new book. However, in this new box, the user can change the name, progress, and genre of a previously created book. 